### PR TITLE
[CARD-2980] Upgrade CI Composer to 2.1.3

### DIFF
--- a/Dockerfile.php-cli
+++ b/Dockerfile.php-cli
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.0.0-experimental
 FROM lendableuk/php-fpm-alpine:7.4.9-alpine3.11 as base
 
-COPY --from=composer:2.0.14 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.1.3 /usr/bin/composer /usr/bin/composer
 
 RUN apk add --no-cache git openssh \
     && mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
Not particularly useful as likely to go away with GitHub Actions replacing our internal Jenkins CI flow for this repo.