### PR TITLE
Remove deprecated rector config

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,10 +11,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PATHS, [__DIR__.'/src', __DIR__.'/tests']);
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
-    $parameters->set(Option::ENABLE_CACHE, true);
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__.'/phpstan.neon');
 
     $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(SetList::CODE_QUALITY_STRICT);
     $containerConfigurator->import(SetList::PHP_74);
 };


### PR DESCRIPTION
`Option::ENABLE_CACHE: @deprecated Cache is enabled by default`
`Option::CODE_QUALITY_STRICT: @deprecated Use only/directly CODE_QUALITY instead` 