### PR TITLE
Remove thecodingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
   "require": {
     "php": ">=7.4.0",
     "beberlei/assert": "^3.3",
-    "ramsey/uuid": "^4.1",
-    "thecodingmachine/safe": "^1.0"
+    "ramsey/uuid": "^4.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.0",
@@ -42,8 +41,7 @@
     "phpstan/phpstan-strict-rules": "^0.12",
     "phpunit/phpunit": "^9.5",
     "qossmic/deptrac-shim": "^0.14 || ^0.15",
-    "rector/rector": "^0.11.5",
-    "thecodingmachine/phpstan-safe-rule": "^1.0"
+    "rector/rector": "^0.11.5"
   },
   "scripts": {
     "security:check": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a3681e357a936b9b78e9decd3bfbf7",
+    "content-hash": "d000208eaa38a697a9c903cbf2fa5997",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -550,145 +550,6 @@
                 }
             ],
             "time": "2021-05-21T13:25:03+00:00"
-        },
-        {
-            "name": "thecodingmachine/safe",
-            "version": "v1.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12",
-                "squizlabs/php_codesniffer": "^3.2",
-                "thecodingmachine/phpstan-strict-rules": "^0.12"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "deprecated/",
-                        "generated/"
-                    ]
-                },
-                "files": [
-                    "deprecated/apc.php",
-                    "deprecated/libevent.php",
-                    "deprecated/mssql.php",
-                    "deprecated/stats.php",
-                    "lib/special_cases.php",
-                    "generated/apache.php",
-                    "generated/apcu.php",
-                    "generated/array.php",
-                    "generated/bzip2.php",
-                    "generated/calendar.php",
-                    "generated/classobj.php",
-                    "generated/com.php",
-                    "generated/cubrid.php",
-                    "generated/curl.php",
-                    "generated/datetime.php",
-                    "generated/dir.php",
-                    "generated/eio.php",
-                    "generated/errorfunc.php",
-                    "generated/exec.php",
-                    "generated/fileinfo.php",
-                    "generated/filesystem.php",
-                    "generated/filter.php",
-                    "generated/fpm.php",
-                    "generated/ftp.php",
-                    "generated/funchand.php",
-                    "generated/gmp.php",
-                    "generated/gnupg.php",
-                    "generated/hash.php",
-                    "generated/ibase.php",
-                    "generated/ibmDb2.php",
-                    "generated/iconv.php",
-                    "generated/image.php",
-                    "generated/imap.php",
-                    "generated/info.php",
-                    "generated/ingres-ii.php",
-                    "generated/inotify.php",
-                    "generated/json.php",
-                    "generated/ldap.php",
-                    "generated/libxml.php",
-                    "generated/lzf.php",
-                    "generated/mailparse.php",
-                    "generated/mbstring.php",
-                    "generated/misc.php",
-                    "generated/msql.php",
-                    "generated/mysql.php",
-                    "generated/mysqli.php",
-                    "generated/mysqlndMs.php",
-                    "generated/mysqlndQc.php",
-                    "generated/network.php",
-                    "generated/oci8.php",
-                    "generated/opcache.php",
-                    "generated/openssl.php",
-                    "generated/outcontrol.php",
-                    "generated/password.php",
-                    "generated/pcntl.php",
-                    "generated/pcre.php",
-                    "generated/pdf.php",
-                    "generated/pgsql.php",
-                    "generated/posix.php",
-                    "generated/ps.php",
-                    "generated/pspell.php",
-                    "generated/readline.php",
-                    "generated/rpminfo.php",
-                    "generated/rrd.php",
-                    "generated/sem.php",
-                    "generated/session.php",
-                    "generated/shmop.php",
-                    "generated/simplexml.php",
-                    "generated/sockets.php",
-                    "generated/sodium.php",
-                    "generated/solr.php",
-                    "generated/spl.php",
-                    "generated/sqlsrv.php",
-                    "generated/ssdeep.php",
-                    "generated/ssh2.php",
-                    "generated/stream.php",
-                    "generated/strings.php",
-                    "generated/swoole.php",
-                    "generated/uodbc.php",
-                    "generated/uopz.php",
-                    "generated/url.php",
-                    "generated/var.php",
-                    "generated/xdiff.php",
-                    "generated/xml.php",
-                    "generated/xmlrpc.php",
-                    "generated/yaml.php",
-                    "generated/yaz.php",
-                    "generated/zip.php",
-                    "generated/zlib.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v1.3.3"
-            },
-            "time": "2020-10-28T17:51:34+00:00"
         }
     ],
     "packages-dev": [
@@ -4773,63 +4634,6 @@
                 }
             ],
             "time": "2021-08-26T08:00:08+00:00"
-        },
-        {
-            "name": "thecodingmachine/phpstan-safe-rule",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/phpstan-safe-rule.git",
-                "reference": "1a1ae26c29011d2d48636353ecadf7fc40997401"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/1a1ae26c29011d2d48636353ecadf7fc40997401",
-                "reference": "1a1ae26c29011d2d48636353ecadf7fc40997401",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^0.10 | ^0.11 | ^0.12",
-                "thecodingmachine/safe": "^1.0"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^7.5.2",
-                "squizlabs/php_codesniffer": "^3.4"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                },
-                "phpstan": {
-                    "includes": [
-                        "phpstan-safe-rule.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TheCodingMachine\\Safe\\PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Négrier",
-                    "email": "d.negrier@thecodingmachine.com"
-                }
-            ],
-            "description": "A PHPStan rule to detect safety issues. Must be used in conjunction with thecodingmachine/safe",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/phpstan-safe-rule/issues",
-                "source": "https://github.com/thecodingmachine/phpstan-safe-rule/tree/v1.0.1"
-            },
-            "time": "2020-08-30T11:41:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,12 +2,11 @@ includes:
   - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
   - vendor/phpstan/phpstan-phpunit/extension.neon
   - vendor/phpstan/phpstan-strict-rules/rules.neon
-  - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
 
 parameters:
   level: max
   treatPhpDocTypesAsCertain: false
-  checkExplicitMixed: true  
+  checkExplicitMixed: true
 
   ignoreErrors:
     - '#^Dynamic call to static method PHPUnit\\Framework\\(TestCase|Assert)::[a-zA-Z]+\(\)\.$#'

--- a/src/CannotExtractAggregateId.php
+++ b/src/CannotExtractAggregateId.php
@@ -15,7 +15,7 @@ final class CannotExtractAggregateId extends \RuntimeException
     private function __construct(object $aggregateRoot, string $cause = '', ?\Throwable $previous = null)
     {
         parent::__construct(
-            \Safe\sprintf(
+            \sprintf(
                 'Cannot extract an aggregate id from aggregate root %s<%s>.',
                 \get_class($aggregateRoot),
                 \spl_object_hash($aggregateRoot)

--- a/src/CannotResolveAggregateType.php
+++ b/src/CannotResolveAggregateType.php
@@ -15,7 +15,7 @@ final class CannotResolveAggregateType extends \RuntimeException
     private function __construct(object $aggregateRoot, string $cause = '', ?\Throwable $previous = null)
     {
         parent::__construct(
-            \Safe\sprintf(
+            \sprintf(
                 'Cannot resolve an aggregate type for aggregate root %s<%s>.',
                 \get_class($aggregateRoot),
                 \spl_object_hash($aggregateRoot)

--- a/tests/fixture/Blog/Domain/UserId.php
+++ b/tests/fixture/Blog/Domain/UserId.php
@@ -28,7 +28,7 @@ final class UserId
 
         if (!$fields instanceof FieldsInterface || $fields->getVersion() !== 4) {
             throw new \InvalidArgumentException(
-                \Safe\sprintf('UUID must be V4, the provided string %s does not conform.', $uuid)
+                \sprintf('UUID must be V4, the provided string %s does not conform.', $uuid)
             );
         }
 

--- a/tests/fixture/Blog/Domain/Version.php
+++ b/tests/fixture/Blog/Domain/Version.php
@@ -11,7 +11,7 @@ final class Version
     private function __construct(int $value)
     {
         if ($value < 1) {
-            throw new \InvalidArgumentException(\Safe\sprintf('Value must be > 0, %d given.', $value));
+            throw new \InvalidArgumentException(\sprintf('Value must be > 0, %d given.', $value));
         }
 
         $this->value = $value;

--- a/tests/helper/ValueObjectAssertions.php
+++ b/tests/helper/ValueObjectAssertions.php
@@ -1,5 +1,6 @@
 <?php
 
+
 declare(strict_types=1);
 
 namespace Tests\Helper\Lendable\Aggregate;
@@ -14,7 +15,7 @@ trait ValueObjectAssertions
     {
         $this->assertTrue(
             $assertion,
-            \Safe\sprintf('Expected "%s", got "%s".', $expected, $actual)
+            \sprintf('Expected "%s", got "%s".', $expected, $actual)
         );
     }
 

--- a/tests/unit/CannotExtractAggregateIdTest.php
+++ b/tests/unit/CannotExtractAggregateIdTest.php
@@ -27,7 +27,7 @@ final class CannotExtractAggregateIdTest extends ExceptionTest
 
     private function createExpectedExceptionMessage(object $aggregateRoot, string $cause): string
     {
-        return \Safe\sprintf(
+        return \sprintf(
             'Cannot extract an aggregate id from aggregate root %s<%s>.',
             \get_class($aggregateRoot),
             \spl_object_hash($aggregateRoot)

--- a/tests/unit/CannotResolveAggregateTypeTest.php
+++ b/tests/unit/CannotResolveAggregateTypeTest.php
@@ -27,7 +27,7 @@ final class CannotResolveAggregateTypeTest extends ExceptionTest
 
     private function createExpectedExceptionMessage(object $aggregateRoot, string $cause): string
     {
-        return \Safe\sprintf(
+        return \sprintf(
             'Cannot resolve an aggregate type for aggregate root %s<%s>.',
             \get_class($aggregateRoot),
             \spl_object_hash($aggregateRoot)

--- a/tests/unit/ClosureAggregateTypeResolverTest.php
+++ b/tests/unit/ClosureAggregateTypeResolverTest.php
@@ -23,7 +23,7 @@ final class ClosureAggregateTypeResolverTest extends AggregateTypeResolverSpec
         return new ClosureAggregateTypeResolver(
             static function (object $user): AggregateType {
                 if (!$user instanceof User) {
-                    throw CannotResolveAggregateType::of($user, \Safe\sprintf('Not an instance of %s.', User::class));
+                    throw CannotResolveAggregateType::of($user, \sprintf('Not an instance of %s.', User::class));
                 }
 
                 return AggregateType::fromString('USER');


### PR DESCRIPTION
Remove as:

- Opinionated and due to being a `"files"` based autoload mechanism, forces loading on dependent projects.
- Isn't overhead free, loading alone takes a performance hit.
- PHP 8 support is not yet released.
- Our usage of it is trivial and can be removed without risk (only `sprintf` calls, covered by tests).