### PR TITLE
Run local-php-security-checker in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: "Run linting"
         run: "composer lint"
 
+      - name: "Run security check"
+        run: "composer security:check"
+
       - name: "Run coding style"
         run: "composer code-style:check"
 


### PR DESCRIPTION
This was unintentionally omitted when swapping over to GitHub Actions