### PR TITLE
Fix composer deptrac command definition (again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
       "phpstan analyse --memory-limit=-1 src/ tests/ --ansi --no-progress"
     ],
     "deptrac": [
-      "bin/deptrac analyze deptrac.yaml --ansi --no-progress"
+      "bin/deptrac analyze --ansi --no-progress"
     ],
     "rector:check": [
       "rector --dry-run --ansi --no-progress-bar"


### PR DESCRIPTION
This option was moved to `--config-file` but as we're using the default file name it's not required and we can simplify the command.