### PR TITLE
Move ValueObjectAssertions to src, use from provided testing specifications

### DIFF
--- a/src/Testing/AggregateIdExtractorSpec.php
+++ b/src/Testing/AggregateIdExtractorSpec.php
@@ -7,13 +7,14 @@ namespace Lendable\Aggregate\Testing;
 use Lendable\Aggregate\AggregateId;
 use Lendable\Aggregate\AggregateIdExtractor;
 use PHPUnit\Framework\TestCase;
-use Tests\Unit\Lendable\Aggregate\T;
 
 /**
  * @phpstan-template T of object
  */
 abstract class AggregateIdExtractorSpec extends TestCase
 {
+    use ValueObjectAssertions;
+
     protected const DEFAULT_V4_UUID = 'b96e8609-e6ef-4d62-a29e-45012fdd6d5a';
 
     /**
@@ -38,6 +39,6 @@ abstract class AggregateIdExtractorSpec extends TestCase
         $expectedAggregateId = $this->createExpectedAggregateId();
         $extractedAggregateId = $extractor->extract($aggregate);
 
-        $this->assertTrue($expectedAggregateId->equals($extractedAggregateId));
+        $this->assertAggregateIdEquals($expectedAggregateId, $extractedAggregateId);
     }
 }

--- a/src/Testing/AggregateTypeResolverSpec.php
+++ b/src/Testing/AggregateTypeResolverSpec.php
@@ -7,13 +7,14 @@ namespace Lendable\Aggregate\Testing;
 use Lendable\Aggregate\AggregateType;
 use Lendable\Aggregate\AggregateTypeResolver;
 use PHPUnit\Framework\TestCase;
-use Tests\Unit\Lendable\Aggregate\T;
 
 /**
  * @phpstan-template T of object
  */
 abstract class AggregateTypeResolverSpec extends TestCase
 {
+    use ValueObjectAssertions;
+
     /**
      * @phpstan-return AggregateTypeResolver<T>
      */
@@ -36,6 +37,6 @@ abstract class AggregateTypeResolverSpec extends TestCase
         $expectedAggregateType = $this->createExpectedAggregateType();
         $resolvedAggregateType = $resolver->resolve($aggregate);
 
-        $this->assertTrue($expectedAggregateType->equals($resolvedAggregateType));
+        $this->assertAggregateTypeEquals($expectedAggregateType, $resolvedAggregateType);
     }
 }

--- a/src/Testing/AggregateVersionExtractorSpec.php
+++ b/src/Testing/AggregateVersionExtractorSpec.php
@@ -7,13 +7,14 @@ namespace Lendable\Aggregate\Testing;
 use Lendable\Aggregate\AggregateVersion;
 use Lendable\Aggregate\AggregateVersionExtractor;
 use PHPUnit\Framework\TestCase;
-use Tests\Unit\Lendable\Aggregate\T;
 
 /**
  * @phpstan-template T of object
  */
 abstract class AggregateVersionExtractorSpec extends TestCase
 {
+    use ValueObjectAssertions;
+
     /**
      * @phpstan-return AggregateVersionExtractor<T>
      */
@@ -36,6 +37,6 @@ abstract class AggregateVersionExtractorSpec extends TestCase
         $expectedAggregateVersion = $this->createExpectedAggregateVersion();
         $extractedAggregateVersion = $extractor->extract($aggregate);
 
-        $this->assertTrue($expectedAggregateVersion->equals($extractedAggregateVersion));
+        $this->assertAggregateVersionEquals($expectedAggregateVersion, $extractedAggregateVersion);
     }
 }

--- a/src/Testing/ValueObjectAssertions.php
+++ b/src/Testing/ValueObjectAssertions.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Helper\Lendable\Aggregate;
+namespace Lendable\Aggregate\Testing;
 
 use Lendable\Aggregate\AggregateId;
 use Lendable\Aggregate\AggregateType;


### PR DESCRIPTION
Highlighted by failure in #287.

- Provide `ValueObjectAssertions` for consuming code to use to simplify assertions. 
- Fixes bad import of generic type `T`.
- Use `ValueObjectAssertions` from the provided testing specifications.