### PR TITLE
Rename AggregateIdTestSpec -> AggregateIdSpec for consistency with other specifications

### DIFF
--- a/src/Testing/AggregateIdSpec.php
+++ b/src/Testing/AggregateIdSpec.php
@@ -12,7 +12,7 @@ use Ramsey\Uuid\Uuid;
 use Tests\Fixture\Lendable\Aggregate\FooAggregateId;
 use Tests\Helper\Lendable\Aggregate\UuidUtil;
 
-abstract class AggregateIdTestSpec extends TestCase
+abstract class AggregateIdSpec extends TestCase
 {
     /**
      * @return class-string<AggregateId>

--- a/tests/unit/UuidV4AggregateIdTest.php
+++ b/tests/unit/UuidV4AggregateIdTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Lendable\Aggregate;
 
-use Lendable\Aggregate\Testing\AggregateIdTestSpec;
+use Lendable\Aggregate\Testing\AggregateIdSpec;
 use Lendable\Aggregate\UuidV4AggregateId;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(UuidV4AggregateId::class)]
-final class UuidV4AggregateIdTest extends AggregateIdTestSpec
+final class UuidV4AggregateIdTest extends AggregateIdSpec
 {
     protected function idClass(): string
     {

--- a/tests/unit/UuidV7AggregateIdTest.php
+++ b/tests/unit/UuidV7AggregateIdTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Lendable\Aggregate;
 
-use Lendable\Aggregate\Testing\AggregateIdTestSpec;
+use Lendable\Aggregate\Testing\AggregateIdSpec;
 use Lendable\Aggregate\UuidV7AggregateId;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(UuidV7AggregateId::class)]
-final class UuidV7AggregateIdTest extends AggregateIdTestSpec
+final class UuidV7AggregateIdTest extends AggregateIdSpec
 {
     protected function idClass(): string
     {


### PR DESCRIPTION
Missed this as part of #566 