### PR TITLE
Rely on static analysis for MapAggregateTypeResolver

### DIFF
--- a/src/MapAggregateTypeResolver.php
+++ b/src/MapAggregateTypeResolver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lendable\Aggregate;
 
-use Assert\Assertion;
-
 /**
  * @phpstan-template TAggregateRoot of object
  *
@@ -18,8 +16,6 @@ final class MapAggregateTypeResolver implements AggregateTypeResolver
      */
     public function __construct(private readonly array $map)
     {
-        Assertion::allClassExists(\array_keys($map), 'All map keys must be class names that exist, %s does not exist.');
-        Assertion::allIsInstanceOf($map, AggregateType::class, 'All map values must be instances of '.AggregateType::class.', %s is not.');
     }
 
     public function resolve(object $aggregate): AggregateType

--- a/tests/unit/MapAggregateTypeResolverTest.php
+++ b/tests/unit/MapAggregateTypeResolverTest.php
@@ -23,29 +23,6 @@ final class MapAggregateTypeResolverTest extends TestCase
     }
 
     #[Test]
-    public function throws_if_a_mapped_class_does_not_exist(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('All map keys must be class names that exist, FooBarBaz does not exist.');
-
-        // @phpstan-ignore-next-line intentional undefined class.
-        new MapAggregateTypeResolver([\FooBarBaz::class => AggregateType::fromString('FooBarBaz')]);
-    }
-
-    #[Test]
-    public function throws_if_a_mapped_value_is_not_an_aggregate_type(): void
-    {
-        $badValue = new class () {
-        };
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf('All map values must be instances of %s, %s is not', AggregateType::class, $badValue::class));
-
-        // @phpstan-ignore-next-line intentionally non-compliant value passed.
-        new MapAggregateTypeResolver([\stdClass::class => $badValue]);
-    }
-
-    #[Test]
     public function throws_if_cannot_resolve_an_aggregate_as_not_mapped(): void
     {
         $this->expectException(CannotResolveAggregateType::class);


### PR DESCRIPTION
This will explode with invalid values anyway (though just not ever hit on invalid keys), the static analysis typings mean there is already a safety net for invalid input.