### PR TITLE
Manual assertion of input in AggregateType

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -86,7 +86,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
         'phpdoc_single_line_var_spacing' => true,
-        'phpdoc_to_comment' => true,
+        'phpdoc_to_comment' => false,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
         'increment_style' => ['style' => 'post'],

--- a/src/AggregateType.php
+++ b/src/AggregateType.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Lendable\Aggregate;
 
-use Assert\Assertion;
-use Assert\AssertionFailedException;
-
 /**
  * A type classification of an aggregate.
  */
@@ -18,17 +15,20 @@ final class AggregateType
     private readonly string $value;
 
     /**
-     * @throws AssertionFailedException If $value is empty.
+     * @throws \InvalidArgumentException If $value is empty.
      */
     private function __construct(string $value)
     {
-        Assertion::notEmpty($value, 'Aggregate type cannot be empty.');
+        if (\trim($value) === '') {
+            throw new \InvalidArgumentException('Aggregate type cannot be empty.');
+        }
 
+        /** @var non-empty-string $value */
         $this->value = $value;
     }
 
     /**
-     * @throws AssertionFailedException If $value is empty.
+     * @throws \InvalidArgumentException If $value is empty.
      */
     public static function fromString(string $value): self
     {


### PR DESCRIPTION
Shifting towards ensuring that we can rely on `\InvalidArgumentException` rather than the `AssertionFailedException` interface, which can be overriden globally to throw an exception that doesn't extend `\InvalidArgumentException`.